### PR TITLE
Can't input text in TextFiel

### DIFF
--- a/src/js.cookie.mjs
+++ b/src/js.cookie.mjs
@@ -10,7 +10,7 @@ function extend () {
 }
 
 function decode (s) {
-  return s.replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent)
+  return s.replace(/(%[0-9A-F]{2})+/g, decodeURIComponent)
 }
 
 function init (converter) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -105,7 +105,7 @@ QUnit.test(
   'Call to read cookie when there is another unrelated cookie with malformed encoding in the name',
   function (assert) {
     assert.expect(2)
-    document.cookie = 'BS%BS=1'
+    document.cookie = '%A1=foo'
     document.cookie = 'c=v'
     assert.strictEqual(
       Cookies.get('c'),
@@ -117,7 +117,7 @@ QUnit.test(
       { c: 'v' },
       'should not throw a URI malformed exception when retrieving all cookies'
     )
-    document.cookie = 'BS%BS=1; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+    document.cookie = '%A1=foo; expires=Thu, 01 Jan 1970 00:00:00 GMT'
   }
 )
 


### PR DESCRIPTION
Hexadecimal digits can only contain characters A-F.

In the adapted test the string "BS%BS" was in fact a valid name
according to RFC 6265 (name is a token, token can contain any CHAR
except CTLs or separators, and % is not a separator).